### PR TITLE
don't try to configure droplet in Vagrant

### DIFF
--- a/roles/internal/common/tasks/main.yml
+++ b/roles/internal/common/tasks/main.yml
@@ -1,5 +1,6 @@
 - name: Droplet configuration
   include_tasks: droplet.yml
+  when: ansible_user != 'vagrant'
 - name: User management
   include_tasks: users.yml
 - name: SSH configuration


### PR DESCRIPTION
Cuts out the tasks that aren't applicable when testing configuration locally.