### PR TITLE
disable root SSH access to servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ To run against a live server:
     export $(./digital_ocean.py --env)
     ```
 
-1. Run one of [the playbooks](playbooks). You will use `root` as the `USER` on the first run and your GitHub username on subsequent runs, as `root` access is deprecated. Examples:
+1. Run one of [the playbooks](playbooks). You will use `root` as the `USER` on the first run and your GitHub username on subsequent runs, as `root` access gets removed. Examples:
     * Test connectivity by running [the test Ansible playbook](playbooks/test.yml) against the Droplets [tagged](https://www.digitalocean.com/docs/droplets/how-to/tag/) with `labs`.
 
         ```shell

--- a/roles/internal/common/defaults/main.yml
+++ b/roles/internal/common/defaults/main.yml
@@ -5,5 +5,3 @@ users:
   - chriswhong
   - trbmcginnis
 former_users: []
-
-disable_root: false

--- a/roles/internal/common/tasks/ssh.yml
+++ b/roles/internal/common/tasks/ssh.yml
@@ -3,7 +3,6 @@
     dest: /etc/ssh/sshd_config
     regexp: ^PermitRootLogin
     line: PermitRootLogin no
-  when: disable_root
   notify: Restart SSH
 - name: Disallow SSH authentication with password
   lineinfile:
@@ -22,5 +21,4 @@
     dest: /etc/ssh/sshd_config
     regexp: ^AllowUsers
     line: AllowUsers deployer {{ 'vagrant ' if ansible_user == 'vagrant' else '' }}{{ users|join(' ') }}
-  when: disable_root
   notify: Restart SSH


### PR DESCRIPTION
I've been going without `root` access on test servers and it's working fine, so I think we are ready to bite the bullet and disable across the board.