### PR TITLE
[WAIT TO MERGE] use advanced SSH hardening role

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,7 +1,10 @@
 [defaults]
-
 # there isn't a great way to handle host key checking non-interactively (like in CI), so disable it
 # https://docs.ansible.com/ansible/latest/user_guide/intro_getting_started.html#host-key-checking
 host_key_checking = False
 
 roles_path = roles/internal:roles/external
+
+[ssh_connection]
+# https://github.com/dev-sec/ansible-ssh-hardening/issues/55#issuecomment-189738808
+scp_if_ssh = True

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,4 @@
 - src: andrewsomething.do-agent
+- src: dev-sec.ssh-hardening
 - src: jnv.unattended-upgrades
 - src: znz.dokku

--- a/roles/internal/common/handlers/main.yml
+++ b/roles/internal/common/handlers/main.yml
@@ -1,4 +1,0 @@
-- name: Restart SSH
-  service:
-    name: sshd
-    state: restarted

--- a/roles/internal/common/tasks/ssh.yml
+++ b/roles/internal/common/tasks/ssh.yml
@@ -1,24 +1,14 @@
-- name: Disallow root SSH access
-  lineinfile:
-    dest: /etc/ssh/sshd_config
-    regexp: ^PermitRootLogin
-    line: PermitRootLogin no
-  notify: Restart SSH
-- name: Disallow SSH authentication with password
-  lineinfile:
-    dest: /etc/ssh/sshd_config
-    regexp: ^PasswordAuthentication
-    line: PasswordAuthentication no
-  notify: Restart SSH
-
 # failsafe to help ensure that you don't get locked out of the machine
 - name: Fail if no users are specified
   fail:
     msg: No users are specified
   when: not users
-- name: Only allow specified users to SSH
-  lineinfile:
-    dest: /etc/ssh/sshd_config
-    regexp: ^AllowUsers
-    line: AllowUsers deployer {{ users|join(' ') }}
-  notify: Restart SSH
+
+- name: Harden SSH configuration
+  include_role:
+    name: dev-sec.ssh-hardening
+  vars:
+    ssh_allow_users: deployer {{ users|join(' ') }}
+    # just to be safe
+    ssh_max_auth_retries: 100
+    ssh_print_motd: true


### PR DESCRIPTION
This pull request switches from using custom SSH hardening to using [a more sophisticated Ansible role](https://github.com/dev-sec/ansible-ssh-hardening), which [does things like disabling old ciphers, etc.](https://dev-sec.io/features.html#ssh-hardening)

While I've tested myself, I would like us to run this on another server and have someone other than me test that they can log in, just to be safe.