### PR TITLE
allow SSH from the dokku user

### DIFF
--- a/roles/internal/common/defaults/main.yml
+++ b/roles/internal/common/defaults/main.yml
@@ -5,3 +5,5 @@ users:
   - chriswhong
   - trbmcginnis
 former_users: []
+
+ssh_allow_users: deployer dokku {{ users|join(' ') }}

--- a/roles/internal/common/tasks/ssh.yml
+++ b/roles/internal/common/tasks/ssh.yml
@@ -20,5 +20,5 @@
   lineinfile:
     dest: /etc/ssh/sshd_config
     regexp: ^AllowUsers
-    line: AllowUsers deployer {{ users|join(' ') }}
+    line: AllowUsers {{ ssh_allow_users }}
   notify: Restart SSH


### PR DESCRIPTION
This should re-enable `git push` to Dokku.