### PR TITLE
Re-enable SSH hardening role

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,7 +1,10 @@
 [defaults]
-
 # there isn't a great way to handle host key checking non-interactively (like in CI), so disable it
 # https://docs.ansible.com/ansible/latest/user_guide/intro_getting_started.html#host-key-checking
 host_key_checking = False
 
 roles_path = roles/internal:roles/external
+
+[ssh_connection]
+# https://github.com/dev-sec/ansible-ssh-hardening/issues/55#issuecomment-189738808
+scp_if_ssh = True

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,4 @@
 - src: andrewsomething.do-agent
+- src: dev-sec.ssh-hardening
 - src: jnv.unattended-upgrades
 - src: znz.dokku

--- a/roles/internal/common/defaults/main.yml
+++ b/roles/internal/common/defaults/main.yml
@@ -7,5 +7,8 @@ users:
   - trbmcginnis
 former_users: []
 
-ssh_users: "{{ users + ['deployer', 'dokku'] }}"
+machine_users:
+  - deployer
+  - dokku
+ssh_users: "{{ users + machine_users }}"
 ssh_allow_users: "{{ ssh_users|join(' ') }}"

--- a/roles/internal/common/defaults/main.yml
+++ b/roles/internal/common/defaults/main.yml
@@ -1,3 +1,4 @@
+# real people
 users:
   - afeld
   - allthesignals
@@ -6,4 +7,5 @@ users:
   - trbmcginnis
 former_users: []
 
-ssh_allow_users: deployer dokku {{ users|join(' ') }}
+ssh_users: "{{ users + ['deployer', 'dokku'] }}"
+ssh_allow_users: "{{ ssh_users|join(' ') }}"

--- a/roles/internal/common/handlers/main.yml
+++ b/roles/internal/common/handlers/main.yml
@@ -1,4 +1,0 @@
-- name: Restart SSH
-  service:
-    name: sshd
-    state: restarted

--- a/roles/internal/common/tasks/ssh.yml
+++ b/roles/internal/common/tasks/ssh.yml
@@ -12,7 +12,8 @@
     ssh_max_auth_retries: 100
     ssh_print_motd: true
 
-- meta: flush_handlers
+- name: Restart SSH daemon
+  meta: flush_handlers
 
 - name: Unlock users
   include_tasks: unlock.yml

--- a/roles/internal/common/tasks/ssh.yml
+++ b/roles/internal/common/tasks/ssh.yml
@@ -12,9 +12,6 @@
     ssh_max_auth_retries: 100
     ssh_print_motd: true
 
-- name: Restart SSH daemon
-  meta: flush_handlers
-
 - name: Unlock users
   include_tasks: unlock.yml
   loop: "{{ ssh_users }}"

--- a/roles/internal/common/tasks/ssh.yml
+++ b/roles/internal/common/tasks/ssh.yml
@@ -1,24 +1,19 @@
-- name: Disallow root SSH access
-  lineinfile:
-    dest: /etc/ssh/sshd_config
-    regexp: ^PermitRootLogin
-    line: PermitRootLogin no
-  notify: Restart SSH
-- name: Disallow SSH authentication with password
-  lineinfile:
-    dest: /etc/ssh/sshd_config
-    regexp: ^PasswordAuthentication
-    line: PasswordAuthentication no
-  notify: Restart SSH
-
 # failsafe to help ensure that you don't get locked out of the machine
 - name: Fail if no users are specified
   fail:
     msg: No users are specified
   when: not users
-- name: Only allow specified users to SSH
-  lineinfile:
-    dest: /etc/ssh/sshd_config
-    regexp: ^AllowUsers
-    line: AllowUsers {{ ssh_allow_users }}
-  notify: Restart SSH
+
+- name: Harden SSH configuration
+  include_role:
+    name: dev-sec.ssh-hardening
+  vars:
+    # just to be safe
+    ssh_max_auth_retries: 100
+    ssh_print_motd: true
+
+- meta: flush_handlers
+
+- name: Unlock users
+  include_tasks: unlock.yml
+  loop: "{{ ssh_users }}"

--- a/roles/internal/common/tasks/unlock.yml
+++ b/roles/internal/common/tasks/unlock.yml
@@ -1,0 +1,13 @@
+# Based on https://blog.danivovich.com/2017/08/31/ansible-ssh-hardening-lockout/
+
+- name: Check if {{ item }} is locked
+  command: grep -q "{{ item }}:!:" /etc/shadow
+  register: check_ubuntu_lock
+  ignore_errors: True
+  changed_when: False
+  become: true
+
+- name: Unlock {{ item }}
+  command: usermod -p "*" {{ item }}
+  when: check_ubuntu_lock.rc == 0
+  become: true

--- a/roles/internal/common/tasks/unlock.yml
+++ b/roles/internal/common/tasks/unlock.yml
@@ -5,7 +5,8 @@
   register: check_ubuntu_lock
   ignore_errors: true
   changed_when: false
+  check_mode: false
 
 - name: Unlock {{ item }}
   command: usermod -p "*" {{ item }}
-  when: check_ubuntu_lock and check_ubuntu_lock.rc == 0
+  when: check_ubuntu_lock.rc == 0

--- a/roles/internal/common/tasks/unlock.yml
+++ b/roles/internal/common/tasks/unlock.yml
@@ -3,11 +3,9 @@
 - name: Check if {{ item }} is locked
   command: grep -q "{{ item }}:!:" /etc/shadow
   register: check_ubuntu_lock
-  ignore_errors: True
-  changed_when: False
-  become: true
+  ignore_errors: true
+  changed_when: false
 
 - name: Unlock {{ item }}
   command: usermod -p "*" {{ item }}
-  when: check_ubuntu_lock.rc == 0
-  become: true
+  when: check_ubuntu_lock and check_ubuntu_lock.rc == 0


### PR DESCRIPTION
Reverts the revert of ssh hardening, adds an additional step to unlock all user accounts.  (See https://blog.danivovich.com/2017/08/31/ansible-ssh-hardening-lockout/)